### PR TITLE
Update BestieTemplate.jl URL to JuliaBesties

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -19,4 +19,4 @@ PackageUUID: ae51599a-cf74-5024-b3c4-c176a83403a4
 RunJuliaNightlyOnCI: true
 UseCirrusCI: true
 _commit: v0.9.1
-_src_path: https://github.com/abelsiqueira/BestieTemplate.jl
+_src_path: https://github.com/JuliaBesties/BestieTemplate.jl


### PR DESCRIPTION
This is a semi-automated PR.
BestieTemplate.jl has been moved to the JuliaBesties organization.
This updates the URL in .copier-answers.yml to point to the new location.
